### PR TITLE
Add support for x86-64 Darwin architecture [#14]

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
       projectRoot = builtins.path { path = ./.; name = "projectRoot"; };
     in
     dream2nix.lib.makeFlakeOutputs {
-      systems = [ "x86_64-linux" ];
+      systems = [ "x86_64-linux" "x86_64-darwin" ];
       config.projectRoot = projectRoot;
       source = projectRoot;
     };


### PR DESCRIPTION
As per #14, this adds support for x86-64 Darwin, as an initial/test platform target.