### PR TITLE
In order to find the *.nix files, the NixService.nixPath function needs to calculate a path one further up the hierarchy [#18]

### DIFF
--- a/src/components/nix/NixService.ts
+++ b/src/components/nix/NixService.ts
@@ -9,7 +9,7 @@ import { NixOptions, Path } from "../../types.js";
 export class NixService implements INixService {
   public eval(file: Path, options: NixOptions) {
     const nixPath = (f: Path) => {
-      return path.join(import.meta.url.replace("file:", ""), "..", "..", "..", "nix", f);
+      return path.join(import.meta.url.replace("file:", ""), "..", "..", "..", "..", "nix", f);
     }
 
     const generateCallArgs = (a: {}) => {


### PR DESCRIPTION
As per #18