### PR TITLE
fix settings being ignored

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -40,7 +40,11 @@ export class App implements IApp {
       args.paths.push(testFile.path);
     }
 
-    if (args.watch === true || schema.settings.watch === true) {
+    args.verbose = [args.verbose[0] || schema.settings.verbose, args.verbose[1] || schema.settings.trace];
+    args.list = args.list || schema.settings.list;
+    args.watch = args.watch || schema.settings.watch;
+
+    if (args.watch) {
       this.watcher.add(args.paths);
       this.watcher.on("all", () => {
         this.run(args);


### PR DESCRIPTION
Settings attrset:
```nix
{
  "verbose" = true;
  "list" = false;
  "trace" = false;
  "watch" = false;
}
```

No CLI args provided.

Two suites, each has:
- one test that returns `true` named `works`
- one test that returns `false` named `fails`

# Before

Passing tests are not printed as expected:

```bash
$ nixt

Found 4 cases in 2 suites over 1 files.

┏ /nix/store/9jvp1z2q48p5vah4g35kjpnmzx7nx3n-source/day01/test.nix
┃   suite1
┃     ✗ fails
┃
┃   suite2
┃     ✗ fails
```

# After

Passing tests are printed as expected:

```bash
$ nixt

Found 4 cases in 2 suites over 1 files.

┏ /nix/store/5rn93pyw49mh7yzsgbqk6f2if4p0cg0-source/day01/test.nix
┃   suite1
┃     ✗ fails
┃     ✓ works
┃
┃   suite2
┃     ✗ fails
┗     ✓ works
```
